### PR TITLE
Fix "osu! Mappool Compliance Checker" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is a collection of useful tools and resources for managing an osu! tourname
 
 ### Automation/Bots
 
-- [osu! Mappool Compliance Checker](https://github.com/hburn7/awesome-osu-tournaments/tree/master) (by Stage) - A Discord bot that checks a list of maps against osu!'s [content usage permissions](https://osu.ppy.sh/wiki/en/Rules/Content_usage_permissions) rules.
+- [osu! Mappool Compliance Checker](https://github.com/hburn7/mappool-compliance-checker) (by Stage) - A Discord bot that checks a list of maps against osu!'s [content usage permissions](https://osu.ppy.sh/wiki/en/Rules/Content_usage_permissions) rules.
 - [Player avatar download bulk tool](https://git.omkserver.nl/omkelderman/player-avatar-download-bulk-tool) (by oliebol) - Download osu! avatar images in bulk so you can use them in places like osu!lazer.
 - [Tosurnament](https://github.com/SpartanPlume/Tosurnament) (by SpartanPlume) - Discord bot that automates most Discord/spreadsheet relationships.
 - [osu! Lazer Tournament Client Bracket Generator CLI](https://github.com/DRCallaghan/osu-lazer-qualifier-results-bracket-generator) (by D I O) - Command-line interfacing program for automatically generating a complete bracket.json file for the osu! Lazer tournament client by taking qualifier results, player and team information, qualifier pool information, and tournament information.


### PR DESCRIPTION
The "osu! Mappool Compliance Checker" link currently links to an outdated fork of this list, not the tool itself.